### PR TITLE
Fix/rpc connection threadsafe

### DIFF
--- a/micro_framework/entrypoints.py
+++ b/micro_framework/entrypoints.py
@@ -44,18 +44,19 @@ class TimeEntrypoint(Entrypoint):
         self.runner.spawn_extension(self, self.run)
 
     def run(self):
+        last_time = timer()
         while self.running:
-            t1 = timer()
+            elapsed_time = timer() - last_time
+            sleep_time = self.interval - elapsed_time
+            if sleep_time > 0:
+                time.sleep(sleep_time)
+            last_time = timer()
             entry_id = uuid.uuid4()
             now = datetime.utcnow()
             try:
                 self.call_route(entry_id, now.isoformat())
             except (ExtensionIsStopped, PoolStopped):
                 pass
-            elapsed_time = timer() - t1
-            sleep_time = self.interval - elapsed_time
-            if sleep_time > 0:
-                time.sleep(sleep_time)
 
     def stop(self):
         self.running = False

--- a/micro_framework/runner.py
+++ b/micro_framework/runner.py
@@ -112,11 +112,6 @@ class Runner:
 
         logger.info("Stopping all extensions and workers")
 
-        # Summary: Please Stop!!
-        self.event_loop.call_soon_threadsafe(self.event_loop.stop)
-        self.event_loop.stop()
-        self.event_loop.close()
-
         # Stopping Entrypoints First
         self._call_extensions_action('stop', extension_set=self.routes)
         # Stop Workers
@@ -128,6 +123,10 @@ class Runner:
         # Stop running extensions
         logger.debug("Stopping any still running extensions thread")
         self.extension_spawner.stop(wait=False)
+
+        # Summary: Please Stop!!
+        self.event_loop.call_soon_threadsafe(self.event_loop.stop)
+        self.event_loop.stop()
         self.event_loop.close()
 
     def spawn_worker(self, worker, *fn_args, callback=None, **fn_kwargs):

--- a/micro_framework/websocket/client.py
+++ b/micro_framework/websocket/client.py
@@ -1,57 +1,17 @@
 import websockets
 from websocket import create_connection
 
-from micro_framework.rpc import RPCClient
+from micro_framework.rpc import RPCClient, RPCConnection
 
 
-class WebSocketClient(RPCClient):
-    """
-    Implements a WebSocket Client as a context manager.
-
-    This client is a synchronous client and using it as a context manager
-    you won't have to remember closing the connection.
-
-    Usage:
-
-    with WebSocketClient(address, port) as client:
-        client.send(message)
-        message = client.recv()
-
-    """
-
-    def __init__(self, address, port, timeout=None):
-        self.address = address
-        self.port = port
-        self.uri = f"ws://{address}:{port}"
+class WebSocketConnection(RPCConnection):
+    def __init__(self, uri, timeout=None):
+        self.uri = uri
         self.timeout = timeout
 
     def __enter__(self):
         self.connection = create_connection(self.uri, timeout=self.timeout)
-        return self
+        return self.connection
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.connection.close()
-
-    def send(self, message):
-        self.connection.send(message)
-
-    def recv(self):
-        return self.connection.recv()
-
-
-class AsyncWebSocketClient(websockets.connect):
-    """
-    Asyncio WebSocket Client
-
-    Since it is an asyncio client, it needs to be ran inside an event-loop.
-
-    Usage:
-    async with AsyncWebSocketClient(addr, port) as client:
-        await client.send(message)
-        response = await client.recv(message)
-
-    """
-
-    def __init__(self, addr, port):
-        self.uri = f"ws://{addr}:{port}"
-        super(AsyncWebSocketClient, self).__init__(self.uri)

--- a/micro_framework/websocket/dependencies.py
+++ b/micro_framework/websocket/dependencies.py
@@ -1,13 +1,16 @@
 from micro_framework.rpc import RPCDependency
-from micro_framework.websocket.client import WebSocketClient
+from micro_framework.websocket.client import WebSocketConnection
 
 
 class WebSocketRPCClient(RPCDependency):
-    client_class = WebSocketClient
+    connection_class = WebSocketConnection
 
-    def __init__(self, address, port):
+    def __init__(self, address, port, timeout=None):
         self.address = address
         self.port = port
+        self.timeout = timeout
 
-    def get_client_kwargs(self):
-        return {'address': self.address, 'port': self.port}
+    def get_connection_kwargs(self):
+        return {
+            'uri': f"ws://{self.address}:{self.port}", 'timeout': self.timeout
+        }

--- a/micro_framework/websocket/entrypoints.py
+++ b/micro_framework/websocket/entrypoints.py
@@ -1,6 +1,7 @@
 from functools import partial
 
 from micro_framework.entrypoints import Entrypoint
+from micro_framework.exceptions import FrameworkException
 from micro_framework.websocket.manager import WebSocketManager
 
 
@@ -27,7 +28,7 @@ class WebSocketEntrypoint(Entrypoint):
         )
 
     def on_failure(self, entry_id):
-        exception = FrameWorkException("RPC Server failed unexpectedly.")
+        exception = FrameworkException("RPC Server failed unexpectedly.")
         self.manager.send_to_client(
             entry_id, data=None, exception=exception
         )


### PR DESCRIPTION
Transformed the RPCCommunication from RPCClient into Threadsafe. 

Previously the client was sharing the connection between threads when called multiple times. Now it instantiates a RPCConnection class that implements the context manager methods to handle the connection.

