### PR TITLE
Fix/class rpc calls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     name='micro-framework',
     url='https://github.com/Mendes11/micro_framework',
-    version='1.3.1',
+    version='1.3.2',
     description='Framework to create CPU or IO bound microservices.',
     long_description= 'file: README.md',
     author = 'Rafael Mendes Pacini Bachiega',


### PR DESCRIPTION
Fix for RPC Calls using classes.

Previously the class methods were not being called due to the method_name being a nested target.


To solve this issue, now `RPCProxy` allows for nested targets, setting a new `RPCProxy` representing the class and inside this new `RPCProxy` it sets the `RPCTarget`.