### PR TITLE
Feature/websocket rpc prefetch count

### DIFF
--- a/micro_framework/exceptions.py
+++ b/micro_framework/exceptions.py
@@ -17,5 +17,12 @@ class RPCException(FrameworkException):
     def __init__(self, exception_dict):
         self.exc_type = exception_dict['exception']
         self.value = exception_dict['message']
-        message = f"{self.exc_type} {self.value}"
+        if self.value:
+            message = f"{self.exc_type} {self.value}"
+        else:
+            message = self.exc_type
         super(RPCException, self).__init__(message)
+
+
+class MaxConnectionsReached(FrameworkException):
+    pass

--- a/micro_framework/runner.py
+++ b/micro_framework/runner.py
@@ -253,7 +253,7 @@ class RunnerContext:
 
     @property
     def available_workers(self):
-        return len(self.running_routes) - self.max_workers
+        return self.max_workers - len(self.running_routes)
 
 
 class Runner:

--- a/micro_framework/spawners/thread.py
+++ b/micro_framework/spawners/thread.py
@@ -18,8 +18,9 @@ def thread_worker(executor, write_queue):
             if executor.shutdown_signal or task_id is None:
                 # Shutdown signal
                 return
-        task = executor._tasks.pop(task_id)  # Remove to avoid Mem. inflating.
-        task.run()
+        task = executor._tasks.pop(task_id, None)  # Remove to avoid Mem. inflating.
+        if task is not None:
+            task.run()
 
 
 class ThreadSpawner(Spawner, _base.Executor):

--- a/micro_framework/websocket/dependencies.py
+++ b/micro_framework/websocket/dependencies.py
@@ -1,9 +1,12 @@
 from micro_framework.rpc import RPCDependency
 from micro_framework.websocket.client import WebSocketConnection
+from micro_framework.websocket.rpc import WSRPCProxy
 
 
 class WebSocketRPCClient(RPCDependency):
     connection_class = WebSocketConnection
+    proxy_class = WSRPCProxy
+
 
     def __init__(self, address, port, timeout=None):
         self.address = address

--- a/micro_framework/websocket/entrypoints.py
+++ b/micro_framework/websocket/entrypoints.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 from micro_framework.entrypoints import Entrypoint
-from micro_framework.exceptions import FrameworkException
+from micro_framework.exceptions import FrameworkException, MaxConnectionsReached
 from micro_framework.websocket.manager import WebSocketManager
 
 
@@ -17,6 +17,8 @@ class WebSocketEntrypoint(Entrypoint):
         :param message:
         :return:
         """
+        if self.runner.available_workers <= 0:
+            raise MaxConnectionsReached("No Available Workers")
         self.runner.event_loop.run_in_executor(
             None,
             func=partial(self.call_route, websocket, *args, **kwargs)

--- a/micro_framework/websocket/rpc.py
+++ b/micro_framework/websocket/rpc.py
@@ -1,0 +1,30 @@
+import time
+
+from micro_framework.exceptions import MaxConnectionsReached
+from micro_framework.rpc import RPCTarget, parse_rpc_response, RPCProxy
+
+
+class WSRPCTarget(RPCTarget):
+    def call(self, message, client):
+        connection_successful = False
+        result = None
+        while not connection_successful:
+            # Try connecting to a server with available workers.
+            # This is useful when the WS Entrypoint is behind a Load Balancer
+            # and therefore we have multiple WebSocket servers, with some empty
+            # and others not.
+
+            with client.get_connection() as connection:
+                connection.send(message)
+                result_message = connection.recv()
+            result = parse_rpc_response(result_message)
+            if isinstance(result, MaxConnectionsReached):
+                time.sleep(0.5)
+                continue  # Keep Trying
+
+            connection_successful = True
+        return result
+
+
+class WSRPCProxy(RPCProxy):
+    target_class = WSRPCTarget

--- a/micro_framework/workers.py
+++ b/micro_framework/workers.py
@@ -63,12 +63,12 @@ class Worker:
         try:
             self.result = fn(*fn_args, **fn_kwargs)
         except Exception as exc:
-            if self.config.get('WORKER_MODE', 'thread') == 'process':
-                # Trick from concurrent.futures to keep the traceback in
-                # process type worker.
-                self.exception = _ExceptionWithTraceback(exc, exc.__traceback__)
-            else:
-                self.exception = exc
+            # if self.config.get('WORKER_MODE', 'thread') == 'process':
+            #     # Trick from concurrent.futures to keep the traceback in
+            #     # process type worker.
+            #     self.exception = _ExceptionWithTraceback(exc, exc.__traceback__)
+            # else:
+            self.exception = exc
 
             self.call_dependencies(
                 self._dependencies, 'after_call', self, self.result, exc

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     name='micro-framework',
     url='https://github.com/Mendes11/micro_framework',
-    version='1.5.1',
+    version='1.5.2',
     description='Framework to create CPU or IO bound microservices.',
     long_description= 'file: README.md',
     author = 'Rafael Mendes Pacini Bachiega',


### PR DESCRIPTION
WebSocket RPC will now raise MaxConnectionsReached when a call to one of its entrypoints is made and the entrypoint context has ran out of available workers.

This will be internally handled by the RPC thread task which will try again every .5 seconds. 

The main reason is to enable the client to connect to another UFW server (Behind a Load Balancer), that might have available workers.

!closes #23 