### PR TITLE
Python 3.14 compatibility

### DIFF
--- a/micro_framework/runner.py
+++ b/micro_framework/runner.py
@@ -406,7 +406,11 @@ class Runner:
 
 
     def start(self):
-        self.event_loop = asyncio.get_event_loop()
+        try:
+            self.event_loop = asyncio.get_event_loop()
+        except RuntimeError:
+            self.event_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self.event_loop)
         self.event_loop.set_exception_handler(self.exception_handler)
         try:
             self.event_loop.run_until_complete(self._start())

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["tests"]),
     name='micro-framework',
     url='https://github.com/Mendes11/micro_framework',
-    version='2.1.0',
+    version='2.1.1',
     description='Framework to create CPU or IO bound microservices.',
     long_description= 'file: README.md',
     author = 'Rafael Mendes Pacini Bachiega',


### PR DESCRIPTION
Enables python 3.14 compatibility

- method [get_event_loop](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop) from asyncio deprecated for python 3.14